### PR TITLE
feat: 1466 - label for only rent one parking space

### DIFF
--- a/packages/frontend/src/pages/ParkingSpace/components/Applicants.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/components/Applicants.tsx
@@ -68,8 +68,12 @@ export const Applicants = (props: { listingId: string }) => {
     {
       field: 'applicationType',
       headerName: 'Ärende',
-      renderCell: (v) => v.formattedValue || <i>N/A</i>,
-      valueFormatter: (v) => (v.value === 'Replace' ? 'Byte' : 'Hyra flera'),
+      renderCell: (v) => {
+        const hasParkingSpace = Boolean(v.row.parkingSpaceContracts?.length)
+        if (v.value === 'Additional')
+          return hasParkingSpace ? 'Hyra flera' : 'Hyra en'
+        else return 'Byte'
+      },
       ...sharedProps,
     },
     {


### PR DESCRIPTION
Adds a label for the case when someone wants to rent one parking space

The logic used for this shed light on that we have an impossible state (i think). An applicant could potentially (from the type) have no parking space contracts AND applicationType 'Replace'.