### PR TITLE
feat: MIM-42 add button to be able to start offer round

### DIFF
--- a/packages/backend/src/services/leasing-service/adapters/core-adapter.ts
+++ b/packages/backend/src/services/leasing-service/adapters/core-adapter.ts
@@ -165,6 +165,22 @@ const createNoteOfInterestForInternalParkingSpace = async (params: {
   }
 }
 
+const createOffer = async (params: {
+  listingId: string
+}): Promise<AdapterResult<unknown, unknown>> => {
+  try {
+    const response = await getFromCore<any>({
+      method: 'post',
+      url: `${coreBaseUrl}/listings/${params.listingId}/offers`,
+      data: params,
+    })
+
+    return { ok: true, data: response.data.content }
+  } catch (err) {
+    return { ok: false, err }
+  }
+}
+
 const syncInternalParkingSpacesFromXpand = async (): Promise<
   AdapterResult<InternalParkingSpaceSyncSuccessResponse, 'unknown'>
 > => {
@@ -192,4 +208,5 @@ export {
   validatePropertyRentalRules,
   validateResidentialAreaRentalRules,
   syncInternalParkingSpacesFromXpand,
+  createOffer,
 }

--- a/packages/backend/src/services/leasing-service/index.ts
+++ b/packages/backend/src/services/leasing-service/index.ts
@@ -183,6 +183,23 @@ export const routes = (router: KoaRouter) => {
     }
   })
 
+  router.post('(.*)/listings/:listingId/offers', async (ctx) => {
+    const metadata = generateRouteMetadata(ctx)
+    const params = ctx.request.body
+    const result = await coreAdapter.createOffer(params)
+
+    if (result.ok) {
+      ctx.status = 200
+      ctx.body = {
+        content: result.data,
+        ...metadata,
+      }
+    } else {
+      ctx.status = 500
+      ctx.body = { error: result.err, ...metadata }
+    }
+  })
+
   router.post('(.*)/listings/sync-internal-from-xpand', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
     const result = await coreAdapter.syncInternalParkingSpacesFromXpand()

--- a/packages/frontend/src/pages/ParkingSpace/components/ParkingSpaceInfo.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/components/ParkingSpaceInfo.tsx
@@ -1,6 +1,8 @@
-import { Box, Typography } from '@mui/material'
+import { Box, Button, Typography } from '@mui/material'
+import { ListingStatus } from 'onecore-types'
 
 import { useParkingSpaceListing } from '../hooks/useParkingSpaceListing'
+import { useCreateOffer } from '../hooks/useCreateOffer'
 
 export const ParkingSpaceInfo = (props: { listingId: string }) => {
   const { data: parkingSpaceListing } = useParkingSpaceListing({
@@ -13,78 +15,110 @@ export const ParkingSpaceInfo = (props: { listingId: string }) => {
     currency: 'SEK',
   })
 
+  const createOffer = useCreateOffer()
+
+  const onCreateOffer = () =>
+    createOffer.mutate(props, {
+      onSuccess: () => console.log('cool'),
+    })
+
+  const renderStartOfferProcessButton = (listingStatus: ListingStatus) => {
+    if (listingStatus == ListingStatus.Expired) {
+      return (
+        <Box paddingY="1rem">
+          <Button variant="dark-outlined" onClick={() => onCreateOffer()}>
+            <Box
+              sx={{
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+              }}
+            >
+              Starta erbjudandeomgång
+            </Box>
+          </Button>
+        </Box>
+      )
+    }
+  }
+
   return (
-    <Box display="flex" justifyContent="space-between" gap="4rem">
-      <Box flex="0.5" paddingX="1rem">
-        <Box display="flex" justifyContent="space-between" flex="1">
-          <Typography>Bilplats</Typography>
-          <Box>
-            <Typography fontWeight="bold">
-              {parkingSpaceListing.address}
-            </Typography>
-            <Typography fontWeight="bold" textAlign="right">
-              {parkingSpaceListing.rentalObjectCode}
-            </Typography>
+    <Box>
+      <Box display="flex" justifyContent="space-between" gap="4rem">
+        <Box flex="0.5" paddingX="1rem">
+          <Box display="flex" justifyContent="space-between" flex="1">
+            <Typography>Bilplats</Typography>
+            <Box>
+              <Typography fontWeight="bold">
+                {parkingSpaceListing.address}
+              </Typography>
+              <Typography fontWeight="bold" textAlign="right">
+                {parkingSpaceListing.rentalObjectCode}
+              </Typography>
+            </Box>
+          </Box>
+          <Box height="50px" />
+          <Box display="flex" justifyContent="space-between" flex="1">
+            <Typography>Skyltnummer</Typography>
+            <Box>
+              <Typography fontWeight="bold">{'N/A'}</Typography>
+            </Box>
+          </Box>
+          <Box height="50px" />
+          <Box display="flex" justifyContent="space-between" flex="1">
+            <Typography>Område</Typography>
+            <Box>
+              <Typography fontWeight="bold">
+                {parkingSpaceListing.districtCaption}
+              </Typography>
+            </Box>
+          </Box>
+          <Box display="flex" justifyContent="space-between" flex="1">
+            <Typography>Bilplatstyp</Typography>
+            <Box>
+              <Typography fontWeight="bold">
+                {parkingSpaceListing.objectTypeCaption}
+              </Typography>
+            </Box>
+          </Box>
+          <Box display="flex" justifyContent="space-between" flex="1">
+            <Typography>Hyra</Typography>
+            <Box>
+              <Typography fontWeight="bold">{`${numberFormatter.format(
+                parkingSpaceListing.monthlyRent
+              )}/mån`}</Typography>
+            </Box>
+          </Box>
+          <Box display="flex" justifyContent="space-between" flex="1">
+            <Typography>Sökande</Typography>
+            <Box>
+              <Typography fontWeight="bold">
+                {parkingSpaceListing.applicants?.length ?? 0}
+              </Typography>
+            </Box>
+          </Box>
+          <Box display="flex" justifyContent="space-between" flex="1">
+            <Typography>Datum tilldelas</Typography>
+            <Box>
+              <Typography fontWeight="bold">
+                {dateFormatter.format(
+                  new Date(parkingSpaceListing.publishedTo)
+                )}
+              </Typography>
+            </Box>
+          </Box>
+          <Box display="flex" justifyContent="space-between" flex="1">
+            <Typography>Ledig från och med</Typography>
+            <Box>
+              <Typography fontWeight="bold">
+                {dateFormatter.format(new Date(parkingSpaceListing.vacantFrom))}
+              </Typography>
+            </Box>
           </Box>
         </Box>
-        <Box height="50px" />
-        <Box display="flex" justifyContent="space-between" flex="1">
-          <Typography>Skyltnummer</Typography>
-          <Box>
-            <Typography fontWeight="bold">{'N/A'}</Typography>
-          </Box>
-        </Box>
-        <Box height="50px" />
-        <Box display="flex" justifyContent="space-between" flex="1">
-          <Typography>Område</Typography>
-          <Box>
-            <Typography fontWeight="bold">
-              {parkingSpaceListing.districtCaption}
-            </Typography>
-          </Box>
-        </Box>
-        <Box display="flex" justifyContent="space-between" flex="1">
-          <Typography>Bilplatstyp</Typography>
-          <Box>
-            <Typography fontWeight="bold">
-              {parkingSpaceListing.objectTypeCaption}
-            </Typography>
-          </Box>
-        </Box>
-        <Box display="flex" justifyContent="space-between" flex="1">
-          <Typography>Hyra</Typography>
-          <Box>
-            <Typography fontWeight="bold">{`${numberFormatter.format(
-              parkingSpaceListing.monthlyRent
-            )}/mån`}</Typography>
-          </Box>
-        </Box>
-        <Box display="flex" justifyContent="space-between" flex="1">
-          <Typography>Sökande</Typography>
-          <Box>
-            <Typography fontWeight="bold">
-              {parkingSpaceListing.applicants?.length ?? 0}
-            </Typography>
-          </Box>
-        </Box>
-        <Box display="flex" justifyContent="space-between" flex="1">
-          <Typography>Datum tilldelas</Typography>
-          <Box>
-            <Typography fontWeight="bold">
-              {dateFormatter.format(new Date(parkingSpaceListing.publishedTo))}
-            </Typography>
-          </Box>
-        </Box>
-        <Box display="flex" justifyContent="space-between" flex="1">
-          <Typography>Ledig från och med</Typography>
-          <Box>
-            <Typography fontWeight="bold">
-              {dateFormatter.format(new Date(parkingSpaceListing.vacantFrom))}
-            </Typography>
-          </Box>
-        </Box>
+        <Box border="1px solid black" flex="1" />
       </Box>
-      <Box border="1px solid black" flex="1" />
+      {renderStartOfferProcessButton(parkingSpaceListing.status)}
     </Box>
   )
 }

--- a/packages/frontend/src/pages/ParkingSpace/components/ParkingSpaceInfo.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/components/ParkingSpaceInfo.tsx
@@ -17,10 +17,9 @@ export const ParkingSpaceInfo = (props: { listingId: string }) => {
 
   const createOffer = useCreateOffer()
 
-  const onCreateOffer = () =>
-    createOffer.mutate(props, {
-      onSuccess: () => console.log('cool'),
-    })
+  const onCreateOffer = () => {
+    createOffer.mutate(props, {})
+  }
 
   const renderStartOfferProcessButton = (listingStatus: ListingStatus) => {
     if (listingStatus == ListingStatus.Expired) {

--- a/packages/frontend/src/pages/ParkingSpace/hooks/useCreateOffer.ts
+++ b/packages/frontend/src/pages/ParkingSpace/hooks/useCreateOffer.ts
@@ -24,5 +24,8 @@ export const useCreateOffer = () => {
       queryClient.invalidateQueries({
         queryKey: ['parkingSpaceListing', params.listingId],
       }),
+    onError: (error) => {
+      console.error('error:', error)
+    },
   })
 }

--- a/packages/frontend/src/pages/ParkingSpace/hooks/useCreateOffer.ts
+++ b/packages/frontend/src/pages/ParkingSpace/hooks/useCreateOffer.ts
@@ -1,0 +1,28 @@
+import axios, { AxiosError } from 'axios'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+const backendUrl = import.meta.env.VITE_BACKEND_URL || '/api'
+
+type Params = { listingId: string }
+
+export const useCreateOffer = () => {
+  const queryClient = useQueryClient()
+  return useMutation<unknown, AxiosError, Params>({
+    mutationFn: (params: Params) =>
+      axios.post<unknown>(
+        `${backendUrl}/listings/${params.listingId}/offers`,
+        params,
+        {
+          headers: {
+            Accept: 'application/json',
+            'Access-Control-Allow-Credentials': true,
+          },
+          withCredentials: true,
+        }
+      ),
+    onSuccess: (_, params) =>
+      queryClient.invalidateQueries({
+        queryKey: ['parkingSpaceListing', params.listingId],
+      }),
+  })
+}


### PR DESCRIPTION
https://linear.app/mimer-onecore/issue/MIM-42/starta-erbjudandeprocess-med-knapp-i-medarbetarportalen

* Button on Listing details view to create _initial_ offer
* Error handling? Is this necessary right now? I don't think so because this is very much a primitive start with the need of additional functionality. We'll improve on this as we go instead of getting stuck in details now? 
* Logic to create subsequent offers is missing in backend, will be handled later
* Logic to render actual offer and not the listing is not included - needs discussion 


<img width="1423" alt="image" src="https://github.com/user-attachments/assets/0035f507-9975-4a0d-aafa-213e105ee134">
