### PR TITLE
MIM-109: Use UTC when formatting DateTime

### DIFF
--- a/packages/frontend/src/pages/ParkingSpace/components/Applicants.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/components/Applicants.tsx
@@ -53,7 +53,7 @@ export const Applicants = (props: { listingId: number }) => {
 }
 
 const getColumns = (listingId: number, address: string): Array<GridColDef> => {
-  const dateFormatter = new Intl.DateTimeFormat('sv-SE')
+  const dateFormatter = new Intl.DateTimeFormat('sv-SE', { timeZone: 'UTC' })
   return [
     {
       field: 'name',

--- a/packages/frontend/src/pages/ParkingSpace/components/OfferRound.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/components/OfferRound.tsx
@@ -31,7 +31,7 @@ const sharedProps = {
   flex: 1,
 }
 
-const dateFormatter = new Intl.DateTimeFormat('sv-SE')
+const dateFormatter = new Intl.DateTimeFormat('sv-SE', { timeZone: 'UTC' })
 const columns: GridColDef[] = [
   {
     field: 'name',

--- a/packages/frontend/src/pages/ParkingSpace/components/ParkingSpaceInfo.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/components/ParkingSpaceInfo.tsx
@@ -9,7 +9,7 @@ export const ParkingSpaceInfo = (props: { listingId: string }) => {
     id: props.listingId,
   })
 
-  const dateFormatter = new Intl.DateTimeFormat('sv-SE')
+  const dateFormatter = new Intl.DateTimeFormat('sv-SE', { timeZone: 'UTC' })
   const numberFormatter = new Intl.NumberFormat('sv-SE', {
     style: 'currency',
     currency: 'SEK',

--- a/packages/frontend/src/pages/ParkingSpaces/components/create-applicant-for-listing/ListingInfo.tsx
+++ b/packages/frontend/src/pages/ParkingSpaces/components/create-applicant-for-listing/ListingInfo.tsx
@@ -2,7 +2,7 @@ import { Box, Typography } from '@mui/material'
 import { Listing } from 'onecore-types'
 
 export const ListingInfo = (props: { listing: Listing }) => {
-  const dateFormatter = new Intl.DateTimeFormat('sv-SE')
+  const dateFormatter = new Intl.DateTimeFormat('sv-SE', { timeZone: 'UTC' })
   const numberFormatter = new Intl.NumberFormat('sv-SE', {
     style: 'currency',
     currency: 'SEK',

--- a/packages/frontend/src/pages/ParkingSpaces/index.tsx
+++ b/packages/frontend/src/pages/ParkingSpaces/index.tsx
@@ -20,7 +20,7 @@ const sharedProps = {
 const ParkingSpaces = () => {
   const parkingSpaces = useParkingSpaceListings()
   const [searchString, setSearchString] = useState<string>()
-  const dateFormatter = new Intl.DateTimeFormat('sv-SE')
+  const dateFormatter = new Intl.DateTimeFormat('sv-SE', { timeZone: 'UTC' })
   const numberFormatter = new Intl.NumberFormat('sv-SE', {
     style: 'currency',
     currency: 'SEK',


### PR DESCRIPTION
DateTimes in the backend does not specify a time zone per default but the formatter uses UTC+1 or UTC+2 depending on time of year (daylight savings). Using `'sv-SE'` as locale will per default use UTC+1 or UTC+2 but since we do not use a specific timezone in the backend we need to keep the date as is E.G. by not adding any offset. 

https://linear.app/mimer-onecore/issue/MIM-109/medarbetarportalen-formaterar-datum-med-annan-tidszon-an-databasen