### PR TITLE
MIM-152: show nationalRegistrationNumber and contactCode for applicants

### DIFF
--- a/packages/frontend/src/pages/ParkingSpace/components/Applicants.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/components/Applicants.tsx
@@ -61,10 +61,10 @@ const getColumns = (listingId: number, address: string): Array<GridColDef> => {
       ...sharedProps,
       flex: 1.25,
       renderCell: (params) => (
-        <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <Box style={{ display: 'flex', flexDirection: 'column' }}>
           <Box>{params.row.name}</Box>{' '}
           <Box>{params.row.nationalRegistrationNumber}</Box>
-        </div>
+        </Box>
       ),
     },
     {

--- a/packages/frontend/src/pages/ParkingSpace/components/Applicants.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/components/Applicants.tsx
@@ -1,4 +1,4 @@
-import { Chip, Stack, Typography } from '@mui/material'
+import { Box, Chip, Stack, Typography } from '@mui/material'
 import type { GridColDef } from '@mui/x-data-grid'
 import { ApplicantStatus, LeaseStatus } from 'onecore-types'
 
@@ -58,6 +58,18 @@ const getColumns = (listingId: number, address: string): Array<GridColDef> => {
     {
       field: 'name',
       headerName: 'Namn',
+      ...sharedProps,
+      flex: 1.25,
+      renderCell: (params) => (
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          <Box>{params.row.name}</Box>{' '}
+          <Box>{params.row.nationalRegistrationNumber}</Box>
+        </div>
+      ),
+    },
+    {
+      field: 'contactCode',
+      headerName: 'Kundnummer',
       ...sharedProps,
       flex: 1.25,
     },

--- a/packages/frontend/src/pages/ParkingSpace/components/OfferRound.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/components/OfferRound.tsx
@@ -39,10 +39,10 @@ const columns: GridColDef[] = [
     ...sharedProps,
     flex: 1.25,
     renderCell: (params) => (
-      <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <Box style={{ display: 'flex', flexDirection: 'column' }}>
         <Box>{params.row.name}</Box>{' '}
         <Box>{params.row.nationalRegistrationNumber}</Box>
-      </div>
+      </Box>
     ),
   },
   {

--- a/packages/frontend/src/pages/ParkingSpace/components/OfferRound.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/components/OfferRound.tsx
@@ -1,4 +1,4 @@
-import { Chip } from '@mui/material'
+import { Box, Chip } from '@mui/material'
 import type { GridColDef } from '@mui/x-data-grid'
 import { ApplicantStatus, LeaseStatus, OfferApplicant } from 'onecore-types'
 
@@ -36,6 +36,18 @@ const columns: GridColDef[] = [
   {
     field: 'name',
     headerName: 'Namn',
+    ...sharedProps,
+    flex: 1.25,
+    renderCell: (params) => (
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <Box>{params.row.name}</Box>{' '}
+        <Box>{params.row.nationalRegistrationNumber}</Box>
+      </div>
+    ),
+  },
+  {
+    field: 'contactCode',
+    headerName: 'Kundnummer',
     ...sharedProps,
     flex: 1.25,
   },

--- a/packages/frontend/src/pages/ParkingSpaces/components/create-applicant-for-listing/ContactInfo.tsx
+++ b/packages/frontend/src/pages/ParkingSpaces/components/create-applicant-for-listing/ContactInfo.tsx
@@ -20,6 +20,28 @@ export const ContactInfo = (props: { tenant: Tenant | null }) => (
       flex="1"
       paddingTop="0.5rem"
     >
+      <Typography>Personnumer</Typography>
+      <Box>
+        <Typography>{props.tenant?.nationalRegistrationNumber}</Typography>
+      </Box>
+    </Box>
+    <Box
+      display="flex"
+      justifyContent="space-between"
+      flex="1"
+      paddingTop="0.5rem"
+    >
+      <Typography>Kontaktnummer</Typography>
+      <Box>
+        <Typography>{props.tenant?.contactCode}</Typography>
+      </Box>
+    </Box>
+    <Box
+      display="flex"
+      justifyContent="space-between"
+      flex="1"
+      paddingTop="0.5rem"
+    >
       <Typography>Adress</Typography>
       <Box>
         <Typography>

--- a/packages/frontend/src/pages/ParkingSpaces/components/create-applicant-for-listing/ContactInfo.tsx
+++ b/packages/frontend/src/pages/ParkingSpaces/components/create-applicant-for-listing/ContactInfo.tsx
@@ -31,7 +31,7 @@ export const ContactInfo = (props: { tenant: Tenant | null }) => (
       flex="1"
       paddingTop="0.5rem"
     >
-      <Typography>Kontaktnummer</Typography>
+      <Typography>Kundnummer</Typography>
       <Box>
         <Typography>{props.tenant?.contactCode}</Typography>
       </Box>


### PR DESCRIPTION
@momentiris `OfferApplicant` type does not currently have the fields `nationalRegistrationNumber` and `contactCode` since we didn't need them previously. The columns for these fields added in this PR will therefore be empty in the OfferRound-tab. I think we should add them to the table and update the type. Any cons with doing this? Awaiting your reply before I continue with this :) 

https://linear.app/mimer-onecore/issue/MIM-152/medarbetarportalen-skall-visa-personnummer-och-kundnummer-for-sokande