### PR TITLE
Mim 127/offer round additions

### DIFF
--- a/packages/frontend/src/pages/ParkingSpace/components/Applicants.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/components/Applicants.tsx
@@ -116,16 +116,16 @@ const getColumns = (listingId: number, address: string): Array<GridColDef> => {
     },
     {
       field: 'status',
-      headerName: 'Status ansökan',
+      headerName: 'Status sökande',
       ...sharedProps,
       flex: 1.25,
       valueFormatter: (v) => formatApplicantStatus(v.value),
       renderCell: (v) => <Chip label={v.formattedValue} />,
     },
     {
-      field: 'foo',
-      headerName: 'Svar erbj.',
-      renderCell: (v) => v.value || <i>N/A</i>,
+      field: 'statusResponse',
+      headerName: 'Svar erbjudande',
+      renderCell: (v) => formatApplicantStatusResponse(v.row.status), // Different logic for rendering the same data
       ...sharedProps,
     },
     {
@@ -186,6 +186,20 @@ const applicantStatusFormatMap: Record<ApplicantStatus, string> = {
 
 const formatApplicantStatus = (v: ApplicantStatus) =>
   applicantStatusFormatMap[v]
+
+const applicantStatusResponseMap: Record<ApplicantStatus, string> = {
+  [ApplicantStatus.Active]: '',
+  [ApplicantStatus.Assigned]: '',
+  [ApplicantStatus.AssignedToOther]: '',
+  [ApplicantStatus.WithdrawnByUser]: '',
+  [ApplicantStatus.WithdrawnByManager]: '',
+  [ApplicantStatus.Offered]: 'Inväntar svar',
+  [ApplicantStatus.OfferAccepted]: 'Ja',
+  [ApplicantStatus.OfferDeclined]: 'Nej',
+  [ApplicantStatus.OfferExpired]: 'Nej',
+}
+const formatApplicantStatusResponse = (v: ApplicantStatus) =>
+  applicantStatusResponseMap[v] || ''
 
 const leaseStatusFormatMap: Record<LeaseStatus, string> = {
   [LeaseStatus.Current]: 'Gällande',

--- a/packages/frontend/src/pages/ParkingSpace/components/Applicants.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/components/Applicants.tsx
@@ -125,7 +125,7 @@ const getColumns = (listingId: number, address: string): Array<GridColDef> => {
     {
       field: 'statusResponse',
       headerName: 'Svar erbjudande',
-      renderCell: (v) => formatApplicantStatusResponse(v.row.status), // Different logic for rendering the same data
+      renderCell: (v) => formatApplicantStatusResponse(v.row.status),
       ...sharedProps,
     },
     {

--- a/packages/frontend/src/pages/ParkingSpace/components/OfferRound.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/components/OfferRound.tsx
@@ -15,12 +15,33 @@ export const OfferRound = (props: {
   applicants: Array<OfferApplicant>
   offer: Offer
 }) => {
+  const columns = getColumns(props.offer.expiresAt)
+
+  return (
+    <>
+      <DataGridTable
+        columns={columns}
+        rows={props.applicants}
+        getRowId={(row) => row.id}
+        initialState={{
+          pagination: { paginationModel: { pageSize: 5 } },
+        }}
+        pageSizeOptions={[5, 10, 25]}
+        rowHeight={72}
+        disableRowSelectionOnClick
+        autoHeight
+      />
+    </>
+  )
+}
+
+const getColumns = (expiresAt: Date): Array<GridColDef> => {
   const sharedProps = {
     editable: false,
     flex: 1,
   }
 
-  const columns: GridColDef[] = [
+  return [
     {
       field: 'name',
       headerName: 'Namn',
@@ -84,8 +105,7 @@ export const OfferRound = (props: {
     {
       field: 'expiresAt',
       headerName: 'Svara senast',
-      valueFormatter: (v) =>
-        dateFormatter.format(new Date(props.offer.expiresAt)),
+      valueFormatter: (v) => dateFormatter.format(new Date(expiresAt)),
     },
     {
       field: 'applicationType',
@@ -127,23 +147,6 @@ export const OfferRound = (props: {
       },
     },
   ]
-
-  return (
-    <>
-      <DataGridTable
-        columns={columns as any}
-        rows={props.applicants}
-        getRowId={(row) => row.id}
-        initialState={{
-          pagination: { paginationModel: { pageSize: 5 } },
-        }}
-        pageSizeOptions={[5, 10, 25]}
-        rowHeight={72}
-        disableRowSelectionOnClick
-        autoHeight
-      />
-    </>
-  )
 }
 
 const dateFormatter = new Intl.DateTimeFormat('sv-SE', { timeZone: 'UTC' })

--- a/packages/frontend/src/pages/ParkingSpace/components/OfferRound.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/components/OfferRound.tsx
@@ -1,6 +1,11 @@
 import { Box, Chip } from '@mui/material'
 import type { GridColDef } from '@mui/x-data-grid'
-import { ApplicantStatus, LeaseStatus, OfferApplicant } from 'onecore-types'
+import {
+  ApplicantStatus,
+  LeaseStatus,
+  Offer,
+  OfferApplicant,
+} from 'onecore-types'
 
 import { DataGridTable } from '../../../components'
 import { OfferRoundActions } from './OfferRoundActions'
@@ -8,7 +13,127 @@ import { OfferRoundActions } from './OfferRoundActions'
 export const OfferRound = (props: {
   numRound: number
   applicants: Array<OfferApplicant>
+  offer: Offer
 }) => {
+  const sharedProps = {
+    editable: false,
+    flex: 1,
+  }
+
+  const columns: GridColDef[] = [
+    {
+      field: 'name',
+      headerName: 'Namn',
+      ...sharedProps,
+      flex: 1.25,
+      renderCell: (params) => (
+        <Box style={{ display: 'flex', flexDirection: 'column' }}>
+          <Box>{params.row.name}</Box>{' '}
+          <Box>{params.row.nationalRegistrationNumber}</Box>
+        </Box>
+      ),
+    },
+    {
+      field: 'contactCode',
+      headerName: 'Kundnummer',
+      ...sharedProps,
+      flex: 1.25,
+    },
+    {
+      field: 'queuePoints',
+      headerName: 'Köpoäng',
+      ...sharedProps,
+      flex: 0.75,
+    },
+    {
+      field: 'address',
+      headerName: 'Boendeadress',
+      valueGetter: (v) => v.row.address,
+      ...sharedProps,
+      flex: 1.25,
+    },
+    {
+      field: 'housingLeaseStatus',
+      headerName: 'Status Boendekontrakt',
+      valueFormatter: (v) => formatLeaseStatus(v.value),
+      renderCell: (v) => <Chip label={v.formattedValue} />,
+      ...sharedProps,
+      flex: 1,
+    },
+    {
+      field: 'applicationDate',
+      headerName: 'Anmälan',
+      ...sharedProps,
+      valueFormatter: (v) => dateFormatter.format(new Date(v.value)),
+    },
+    {
+      field: 'hasParkingSpace',
+      headerName: 'Har bilplats',
+      valueFormatter: (v) => (v.value ? 'Ja' : 'Nej'),
+      ...sharedProps,
+      flex: 0.75,
+    },
+    {
+      field: 'status',
+      headerName: 'Status ansökan',
+      ...sharedProps,
+      flex: 1.25,
+      valueFormatter: (v) => formatApplicantStatus(v.value),
+      renderCell: (v) => <Chip label={v.formattedValue} />,
+    },
+    {
+      field: 'statusResponse', // A unique field key that refers to the same `status` field
+      headerName: 'Svar erbj.',
+      renderCell: (v) => formatApplicantStatusResponse(v.row.status), // Different logic for rendering the same data
+      ...sharedProps,
+    },
+    {
+      field: 'expiresAt',
+      headerName: 'Svara senast',
+      valueFormatter: (v) =>
+        dateFormatter.format(new Date(props.offer.expiresAt)),
+    },
+    {
+      field: 'applicationType',
+      headerName: 'Ärende',
+      renderCell: (v) => {
+        if (v.value === 'Additional')
+          return v.row.hasParkingSpace ? 'Hyra flera' : 'Hyra en'
+        else return 'Byte'
+      },
+      ...sharedProps,
+    },
+    {
+      field: 'priority',
+      headerName: 'Prioritetsgrupp',
+      ...sharedProps,
+      valueFormatter: (v) => formatApplicantStatus(v.value),
+      renderCell: (v) => v.value ?? <i>N/A</i>,
+    },
+    {
+      field: 'action',
+      headerName: '',
+      sortable: false,
+      filterable: false,
+      disableColumnMenu: true,
+      align: 'center',
+      renderCell: (v) => {
+        if (v.row.status !== ApplicantStatus.Offered) {
+          return null
+        }
+
+        return (
+          <OfferRoundActions
+            disabled={v.row.status !== ApplicantStatus.Offered}
+            listingId={v.row.listingId}
+            applicantName={v.row.name}
+            offerId={v.row.offerId}
+          />
+        )
+      },
+    },
+  ]
+
   return (
     <>
       <DataGridTable
@@ -27,119 +152,7 @@ export const OfferRound = (props: {
   )
 }
 
-const sharedProps = {
-  editable: false,
-  flex: 1,
-}
-
 const dateFormatter = new Intl.DateTimeFormat('sv-SE', { timeZone: 'UTC' })
-const columns: GridColDef[] = [
-  {
-    field: 'name',
-    headerName: 'Namn',
-    ...sharedProps,
-    flex: 1.25,
-    renderCell: (params) => (
-      <Box style={{ display: 'flex', flexDirection: 'column' }}>
-        <Box>{params.row.name}</Box>{' '}
-        <Box>{params.row.nationalRegistrationNumber}</Box>
-      </Box>
-    ),
-  },
-  {
-    field: 'contactCode',
-    headerName: 'Kundnummer',
-    ...sharedProps,
-    flex: 1.25,
-  },
-  {
-    field: 'queuePoints',
-    headerName: 'Köpoäng',
-    ...sharedProps,
-    flex: 0.75,
-  },
-  {
-    field: 'address',
-    headerName: 'Boendeadress',
-    valueGetter: (v) => v.row.address,
-    ...sharedProps,
-    flex: 1.25,
-  },
-  {
-    field: 'housingLeaseStatus',
-    headerName: 'Status Boendekontrakt',
-    valueFormatter: (v) => formatLeaseStatus(v.value),
-    renderCell: (v) => <Chip label={v.formattedValue} />,
-    ...sharedProps,
-    flex: 1,
-  },
-  {
-    field: 'applicationDate',
-    headerName: 'Anmälan',
-    ...sharedProps,
-    valueFormatter: (v) => dateFormatter.format(new Date(v.value)),
-  },
-  {
-    field: 'hasParkingSpace',
-    headerName: 'Har bilplats',
-    valueFormatter: (v) => (v.value ? 'Ja' : 'Nej'),
-    ...sharedProps,
-    flex: 0.75,
-  },
-  {
-    field: 'status',
-    headerName: 'Status ansökan',
-    ...sharedProps,
-    flex: 1.25,
-    valueFormatter: (v) => formatApplicantStatus(v.value),
-    renderCell: (v) => <Chip label={v.formattedValue} />,
-  },
-  {
-    field: 'foo',
-    headerName: 'Svar erbj.',
-    renderCell: (v) => v.value || <i>N/A</i>,
-    ...sharedProps,
-  },
-  {
-    field: 'applicationType',
-    headerName: 'Ärende',
-    renderCell: (v) => {
-      if (v.value === 'Additional')
-        return v.row.hasParkingSpace ? 'Hyra flera' : 'Hyra en'
-      else return 'Byte'
-    },
-    ...sharedProps,
-  },
-  {
-    field: 'priority',
-    headerName: 'Prioritetsgrupp',
-    ...sharedProps,
-    valueFormatter: (v) => formatApplicantStatus(v.value),
-    renderCell: (v) => v.value ?? <i>N/A</i>,
-  },
-  {
-    field: 'action',
-    headerName: '',
-    sortable: false,
-    filterable: false,
-    disableColumnMenu: true,
-    align: 'center',
-    renderCell: (v) => {
-      if (v.row.status !== ApplicantStatus.Offered) {
-        return null
-      }
-
-      return (
-        <OfferRoundActions
-          disabled={v.row.status !== ApplicantStatus.Offered}
-          listingId={v.row.listingId}
-          applicantName={v.row.name}
-          offerId={v.row.offerId}
-        />
-      )
-    },
-  },
-]
 
 const applicantStatusFormatMap: Record<ApplicantStatus, string> = {
   [ApplicantStatus.Active]: 'Aktiv',
@@ -155,6 +168,20 @@ const applicantStatusFormatMap: Record<ApplicantStatus, string> = {
 
 const formatApplicantStatus = (v: ApplicantStatus) =>
   applicantStatusFormatMap[v]
+
+const applicantStatusResponseMap: Record<ApplicantStatus, string> = {
+  [ApplicantStatus.Active]: '',
+  [ApplicantStatus.Assigned]: '',
+  [ApplicantStatus.AssignedToOther]: '',
+  [ApplicantStatus.WithdrawnByUser]: '',
+  [ApplicantStatus.WithdrawnByManager]: '',
+  [ApplicantStatus.Offered]: 'Inväntar svar',
+  [ApplicantStatus.OfferAccepted]: 'Ja',
+  [ApplicantStatus.OfferDeclined]: 'Nej',
+  [ApplicantStatus.OfferExpired]: 'Nej',
+}
+const formatApplicantStatusResponse = (v: ApplicantStatus) =>
+  applicantStatusResponseMap[v] || ''
 
 const leaseStatusFormatMap: Record<LeaseStatus, string> = {
   [LeaseStatus.Current]: 'Aktivt',

--- a/packages/frontend/src/pages/ParkingSpace/components/OfferRound.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/components/OfferRound.tsx
@@ -75,16 +75,16 @@ export const OfferRound = (props: {
     },
     {
       field: 'status',
-      headerName: 'Status ansökan',
+      headerName: 'Status sökande',
       ...sharedProps,
       flex: 1.25,
       valueFormatter: (v) => formatApplicantStatus(v.value),
       renderCell: (v) => <Chip label={v.formattedValue} />,
     },
     {
-      field: 'statusResponse', // A unique field key that refers to the same `status` field
-      headerName: 'Svar erbj.',
-      renderCell: (v) => formatApplicantStatusResponse(v.row.status), // Different logic for rendering the same data
+      field: 'statusResponse',
+      headerName: 'Svar erbjudande',
+      renderCell: (v) => formatApplicantStatusResponse(v.row.status),
       ...sharedProps,
     },
     {

--- a/packages/frontend/src/pages/ParkingSpace/components/OfferRound.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/components/OfferRound.tsx
@@ -82,12 +82,6 @@ export const OfferRound = (props: {
       renderCell: (v) => <Chip label={v.formattedValue} />,
     },
     {
-      field: 'statusResponse',
-      headerName: 'Svar erbjudande',
-      renderCell: (v) => formatApplicantStatusResponse(v.row.status),
-      ...sharedProps,
-    },
-    {
       field: 'expiresAt',
       headerName: 'Svara senast',
       valueFormatter: (v) =>
@@ -168,20 +162,6 @@ const applicantStatusFormatMap: Record<ApplicantStatus, string> = {
 
 const formatApplicantStatus = (v: ApplicantStatus) =>
   applicantStatusFormatMap[v]
-
-const applicantStatusResponseMap: Record<ApplicantStatus, string> = {
-  [ApplicantStatus.Active]: '',
-  [ApplicantStatus.Assigned]: '',
-  [ApplicantStatus.AssignedToOther]: '',
-  [ApplicantStatus.WithdrawnByUser]: '',
-  [ApplicantStatus.WithdrawnByManager]: '',
-  [ApplicantStatus.Offered]: 'Inväntar svar',
-  [ApplicantStatus.OfferAccepted]: 'Ja',
-  [ApplicantStatus.OfferDeclined]: 'Nej',
-  [ApplicantStatus.OfferExpired]: 'Nej',
-}
-const formatApplicantStatusResponse = (v: ApplicantStatus) =>
-  applicantStatusResponseMap[v] || ''
 
 const leaseStatusFormatMap: Record<LeaseStatus, string> = {
   [LeaseStatus.Current]: 'Aktivt',

--- a/packages/frontend/src/pages/ParkingSpace/components/OfferRoundActions.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/components/OfferRoundActions.tsx
@@ -3,13 +3,13 @@ import { IconButton, Backdrop, Menu } from '@mui/material'
 import PopupState, { bindMenu, bindTrigger } from 'material-ui-popup-state'
 import { MoreHoriz } from '@mui/icons-material'
 import { toast } from 'react-toastify'
+import { ReplyToOfferErrorCodes } from 'onecore-types'
 
 import { useAcceptOffer } from '../hooks/useAcceptOffer'
 import { useDenyOffer } from '../hooks/useDenyOffer'
 import { ActionDialog } from './ActionDialog'
 import { PopupMenuItem } from './PopupMenuItem'
 import { RequestError } from '../../../types'
-import { ReplyToOfferErrorCodes } from 'onecore-types'
 
 export interface Props {
   offerId: number

--- a/packages/frontend/src/pages/ParkingSpace/index.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/index.tsx
@@ -2,7 +2,7 @@ import { Box, Chip, Typography } from '@mui/material'
 import { Suspense, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { TabContext, TabPanel } from '@mui/lab'
-import { ListingStatus, OfferStatus } from 'onecore-types'
+import { ListingStatus, Offer, OfferStatus } from 'onecore-types'
 
 import { PageGoBackTo, Tab, Tabs } from '../../components'
 import {
@@ -40,40 +40,15 @@ const ParkingSpaceTabs = (props: { listingId: number }) => {
     id: props.listingId,
   })
 
-  let initialTab = '1'
-  if (data.status === ListingStatus.Assigned && data.offers.length > 0) {
-    initialTab = String(data.offers[0].id)
-  }
-
-  const [selectedTab, setSelectedTab] = useState(initialTab)
+  const [selectedTab, setSelectedTab] = useState(() => {
+    if (data.status === ListingStatus.Assigned && data.offers.length > 0) {
+      return String(data.offers[0].id)
+    }
+    return '1'
+  })
 
   const handleChange = (_e: React.SyntheticEvent, tab: string) =>
     setSelectedTab(tab)
-
-  //todo: decide on copy for these
-  const listingFormatMap: Record<ListingStatus, string> = {
-    [ListingStatus.Active]: 'Publicerad',
-    [ListingStatus.Assigned]: 'Tilldelad',
-    [ListingStatus.Deleted]: 'Borttagen',
-    [ListingStatus.Expired]: 'Klar för erbjudande',
-  }
-
-  //todo: decide on copy for these
-  const offerFormatMap: Record<OfferStatus, string> = {
-    [OfferStatus.Active]: 'Erbjudande',
-    [OfferStatus.Accepted]: 'Tilldelad / kontrakterad',
-    [OfferStatus.Declined]: 'Nekad',
-    [OfferStatus.Expired]: 'Utgången',
-  }
-
-  const formatStatus = (v: any) => {
-    console.log(data)
-    //if offers exists, the latest offer status is the overall status
-    if (data.offers.length > 0) {
-      return offerFormatMap[data.offers[data.offers.length - 1].status]
-    }
-    return listingFormatMap[data.status]
-  }
 
   return (
     <TabContext value={selectedTab}>
@@ -86,7 +61,10 @@ const ParkingSpaceTabs = (props: { listingId: number }) => {
         <Typography paddingBottom="0.5rem" marginRight="1rem" variant="h1">
           <span>Intresseanmälningar {data.address}</span>
         </Typography>
-        <Chip label={formatStatus(data)} sx={{ marginY: 'auto' }}></Chip>
+        <Chip
+          label={formatStatus(data.offers, data.status)}
+          sx={{ marginY: 'auto' }}
+        ></Chip>
       </Box>
       <Tabs onChange={handleChange}>
         {data.status !== ListingStatus.Assigned && (
@@ -119,4 +97,27 @@ const ParkingSpaceTabs = (props: { listingId: number }) => {
     </TabContext>
   )
 }
+
+const listingFormatMap: Record<ListingStatus, string> = {
+  [ListingStatus.Active]: 'Publicerad',
+  [ListingStatus.Assigned]: 'Tilldelad',
+  [ListingStatus.Deleted]: 'Borttagen',
+  [ListingStatus.Expired]: 'Klar för erbjudande',
+}
+
+const offerFormatMap: Record<OfferStatus, string> = {
+  [OfferStatus.Active]: 'Erbjudande',
+  [OfferStatus.Accepted]: 'Tilldelad / kontrakterad',
+  [OfferStatus.Declined]: 'Nekad',
+  [OfferStatus.Expired]: 'Utgången',
+}
+
+const formatStatus = (offers: Offer[], listingStatus: ListingStatus) => {
+  //if offers exists, the latest offer status is the overall status
+  if (offers.length > 0) {
+    return offerFormatMap[offers[offers.length - 1].status]
+  }
+  return listingFormatMap[listingStatus]
+}
+
 export default ParkingSpace

--- a/packages/frontend/src/pages/ParkingSpace/index.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/index.tsx
@@ -2,7 +2,7 @@ import { Box, Chip, Typography } from '@mui/material'
 import { Suspense, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { TabContext, TabPanel } from '@mui/lab'
-import { ApplicantStatus, ListingStatus, OfferStatus } from 'onecore-types'
+import { ListingStatus, OfferStatus } from 'onecore-types'
 
 import { PageGoBackTo, Tab, Tabs } from '../../components'
 import {
@@ -44,38 +44,25 @@ const ParkingSpaceTabs = (props: { listingId: number }) => {
   const handleChange = (_e: React.SyntheticEvent, tab: string) =>
     setSelectedTab(tab)
 
+  //todo: decide on copy for these
   const listingFormatMap: Record<ListingStatus, string> = {
     [ListingStatus.Active]: 'Publicerad',
     [ListingStatus.Assigned]: 'Tilldelad',
     [ListingStatus.Deleted]: 'Borttagen',
-    //todo: what is the translation here?
-    //todo: the listing will be in the "Klara för erbjudande" tab
-    //todo: when an offer exists offerFormatMap will be used instead
     [ListingStatus.Expired]: 'Klar för erbjudande',
   }
 
+  //todo: decide on copy for these
   const offerFormatMap: Record<OfferStatus, string> = {
-    [OfferStatus.Active]: 'Aktiv',
+    [OfferStatus.Active]: 'Erbjudande',
     [OfferStatus.Accepted]: 'Tilldelad / kontrakterad',
     [OfferStatus.Declined]: 'Nekad',
     [OfferStatus.Expired]: 'Utgången',
   }
 
-  //todo do we need to be this granular?
-  const applicantStatusFormatMap: Record<ApplicantStatus, string> = {
-    [ApplicantStatus.Active]: '',
-    [ApplicantStatus.Assigned]: '',
-    [ApplicantStatus.AssignedToOther]: '',
-    [ApplicantStatus.WithdrawnByUser]: '',
-    [ApplicantStatus.WithdrawnByManager]: '',
-    [ApplicantStatus.Offered]: '',
-    [ApplicantStatus.OfferAccepted]: '',
-    [ApplicantStatus.OfferDeclined]: '',
-    [ApplicantStatus.OfferExpired]: '',
-  }
-
   const formatStatus = (v: any) => {
     console.log(data)
+    //if offers exists, the latest offer status is the overall status
     if (data.offers.length > 0) {
       return offerFormatMap[data.offers[data.offers.length - 1].status]
     }

--- a/packages/frontend/src/pages/ParkingSpace/index.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/index.tsx
@@ -36,10 +36,16 @@ const ParkingSpace = () => {
 }
 
 const ParkingSpaceTabs = (props: { listingId: number }) => {
-  const [selectedTab, setSelectedTab] = useState('1')
   const { data } = useParkingSpaceListing({
     id: props.listingId,
   })
+
+  let initialTab = '1'
+  if (data.status === ListingStatus.Assigned && data.offers.length > 0) {
+    initialTab = String(data.offers[0].id)
+  }
+
+  const [selectedTab, setSelectedTab] = useState(initialTab)
 
   const handleChange = (_e: React.SyntheticEvent, tab: string) =>
     setSelectedTab(tab)
@@ -82,9 +88,10 @@ const ParkingSpaceTabs = (props: { listingId: number }) => {
         </Typography>
         <Chip label={formatStatus(data)} sx={{ marginY: 'auto' }}></Chip>
       </Box>
-
       <Tabs onChange={handleChange}>
-        <Tab disableRipple label="Alla sökande" value="1" />
+        {data.status !== ListingStatus.Assigned && (
+          <Tab disableRipple label="Alla sökande" value="1" />
+        )}
         {data.offers.map((offer, i) => (
           <Tab
             key={offer.id}

--- a/packages/frontend/src/pages/ParkingSpace/index.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/index.tsx
@@ -1,7 +1,8 @@
-import { Box, Typography } from '@mui/material'
+import { Box, Chip, Typography } from '@mui/material'
 import { Suspense, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { TabContext, TabPanel } from '@mui/lab'
+import { ApplicantStatus, ListingStatus, OfferStatus } from 'onecore-types'
 
 import { PageGoBackTo, Tab, Tabs } from '../../components'
 import {
@@ -43,11 +44,58 @@ const ParkingSpaceTabs = (props: { listingId: number }) => {
   const handleChange = (_e: React.SyntheticEvent, tab: string) =>
     setSelectedTab(tab)
 
+  const listingFormatMap: Record<ListingStatus, string> = {
+    [ListingStatus.Active]: 'Publicerad',
+    [ListingStatus.Assigned]: 'Tilldelad',
+    [ListingStatus.Deleted]: 'Borttagen',
+    //todo: what is the translation here?
+    //todo: the listing will be in the "Klara för erbjudande" tab
+    //todo: when an offer exists offerFormatMap will be used instead
+    [ListingStatus.Expired]: 'Klar för erbjudande',
+  }
+
+  const offerFormatMap: Record<OfferStatus, string> = {
+    [OfferStatus.Active]: 'Aktiv',
+    [OfferStatus.Accepted]: 'Tilldelad / kontrakterad',
+    [OfferStatus.Declined]: 'Nekad',
+    [OfferStatus.Expired]: 'Utgången',
+  }
+
+  //todo do we need to be this granular?
+  const applicantStatusFormatMap: Record<ApplicantStatus, string> = {
+    [ApplicantStatus.Active]: '',
+    [ApplicantStatus.Assigned]: '',
+    [ApplicantStatus.AssignedToOther]: '',
+    [ApplicantStatus.WithdrawnByUser]: '',
+    [ApplicantStatus.WithdrawnByManager]: '',
+    [ApplicantStatus.Offered]: '',
+    [ApplicantStatus.OfferAccepted]: '',
+    [ApplicantStatus.OfferDeclined]: '',
+    [ApplicantStatus.OfferExpired]: '',
+  }
+
+  const formatStatus = (v: any) => {
+    console.log(data)
+    if (data.offers.length > 0) {
+      return offerFormatMap[data.offers[data.offers.length - 1].status]
+    }
+    return listingFormatMap[data.status]
+  }
+
   return (
     <TabContext value={selectedTab}>
-      <Typography paddingBottom="0.5rem" variant="h1">
-        Intresseanmälningar {data.address}
-      </Typography>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'row',
+        }}
+      >
+        <Typography paddingBottom="0.5rem" marginRight="1rem" variant="h1">
+          <span>Intresseanmälningar {data.address}</span>
+        </Typography>
+        <Chip label={formatStatus(data)} sx={{ marginY: 'auto' }}></Chip>
+      </Box>
+
       <Tabs onChange={handleChange}>
         <Tab disableRipple label="Alla sökande" value="1" />
         {data.offers.map((offer, i) => (
@@ -68,6 +116,7 @@ const ParkingSpaceTabs = (props: { listingId: number }) => {
             <OfferRound
               key={offer.id}
               applicants={offer.selectedApplicants}
+              offer={offer}
               numRound={i + 1}
             />
           </TabPanel>


### PR DESCRIPTION
https://linear.app/mimer-onecore/issue/MIM-127/medarbetarportalen-visa-erbjudandeomgangar

various improvements to make the detail views on listing and offers to make more sense. 

- Display the correct status of the parking space/listing in the title.
- Hide the "Alla sökande" tab after the status of the listing has been assigned.
- Show responses (yes, no, no response) in a column "Svar erbjudande")on the listing. makes no sense to add this on the offer round since "Status sökande" has the asm
- Add a "Svara senast" column. Added to the offer round, not currently supported for all applicants on listing.


