### PR TITLE
MIM-198: render parking space image in object information

### DIFF
--- a/packages/frontend/src/pages/ParkingSpace/components/ParkingSpaceInfo.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/components/ParkingSpaceInfo.tsx
@@ -54,9 +54,14 @@ export const ParkingSpaceInfo = (props: { listingId: number }) => {
           justifyContent: 'space-between',
           gap: '4rem',
           height: '21rem',
+          '@media (max-width: 62.5rem)': {
+            flexDirection: 'column',
+            gap: '2rem',
+            height: 'auto',
+          },
         }}
       >
-        <Box flex="0.25" paddingX="1rem">
+        <Box flex="0.25" paddingX="1rem" sx={{ minWidth: '400px' }}>
           <Box display="flex" justifyContent="space-between" flex="1">
             <Typography>Bilplats</Typography>
             <Box>
@@ -131,7 +136,6 @@ export const ParkingSpaceInfo = (props: { listingId: number }) => {
           flex="1"
           sx={{
             width: '100%',
-            height: '100%',
             cursor: 'pointer',
           }}
           onClick={() =>
@@ -146,7 +150,9 @@ export const ParkingSpaceInfo = (props: { listingId: number }) => {
             src={getMapImageUrl(parkingSpaceListing.rentalObjectCode)}
             alt="parking space map image"
             sx={{
-              height: '100%',
+              objectFit: 'contain',
+              maxWidth: '100%',
+              maxHeight: '100%',
             }}
           />
         </Box>

--- a/packages/frontend/src/pages/ParkingSpace/components/ParkingSpaceInfo.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/components/ParkingSpaceInfo.tsx
@@ -21,6 +21,11 @@ export const ParkingSpaceInfo = (props: { listingId: number }) => {
     createOffer.mutate(props, {})
   }
 
+  const getMapImageUrl = (rentalObjectCodes: string) => {
+    const identifier = rentalObjectCodes.slice(0, 7)
+    return `https://pub.mimer.nu/bofaktablad/mediabank/byggnad/${identifier}_1.jpg`
+  }
+
   const renderStartOfferProcessButton = (listingStatus: ListingStatus) => {
     if (listingStatus == ListingStatus.Expired) {
       return (
@@ -44,7 +49,7 @@ export const ParkingSpaceInfo = (props: { listingId: number }) => {
   return (
     <Box>
       <Box display="flex" justifyContent="space-between" gap="4rem">
-        <Box flex="0.5" paddingX="1rem">
+        <Box flex="0.25" paddingX="1rem">
           <Box display="flex" justifyContent="space-between" flex="1">
             <Typography>Bilplats</Typography>
             <Box>
@@ -115,7 +120,28 @@ export const ParkingSpaceInfo = (props: { listingId: number }) => {
             </Box>
           </Box>
         </Box>
-        <Box border="1px solid black" flex="1" />
+        <Box
+          flex="1"
+          sx={{
+            height: '24rem',
+            cursor: 'pointer',
+          }}
+          onClick={() =>
+            window.open(
+              getMapImageUrl(parkingSpaceListing.rentalObjectCode),
+              '_blank'
+            )
+          }
+        >
+          <Box
+            component="img"
+            src={getMapImageUrl(parkingSpaceListing.rentalObjectCode)}
+            alt="parking space map image"
+            sx={{
+              height: '100%',
+            }}
+          />
+        </Box>
       </Box>
       {renderStartOfferProcessButton(parkingSpaceListing.status)}
     </Box>

--- a/packages/frontend/src/pages/ParkingSpace/components/ParkingSpaceInfo.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/components/ParkingSpaceInfo.tsx
@@ -48,7 +48,14 @@ export const ParkingSpaceInfo = (props: { listingId: number }) => {
 
   return (
     <Box>
-      <Box display="flex" justifyContent="space-between" gap="4rem">
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          gap: '4rem',
+          height: '21rem',
+        }}
+      >
         <Box flex="0.25" paddingX="1rem">
           <Box display="flex" justifyContent="space-between" flex="1">
             <Typography>Bilplats</Typography>
@@ -123,7 +130,8 @@ export const ParkingSpaceInfo = (props: { listingId: number }) => {
         <Box
           flex="1"
           sx={{
-            height: '24rem',
+            width: '100%',
+            height: '100%',
             cursor: 'pointer',
           }}
           onClick={() =>


### PR DESCRIPTION
https://linear.app/mimer-onecore/issue/MIM-198/hamta-och-visa-kartbild-i-medarbetarportalen

images come in various formats and will never have the same aspect ratio as the example in Figma (from the images I have found) 

Stretching to fill container horizontally is not an option since it simply will look terrible for some of the aspect ratios. I've opted to keep aspect ratio as is, see screenshots. I don't know what the code on Mimer.nu is intending to do but in a lot of cases the cropping simply does not work there. Better to just show the full image as is and make it clickable to open in new browser tab if you need to see the a larger version I think.


<img width="821" alt="Screenshot 2024-10-23 at 14 58 23" src="https://github.com/user-attachments/assets/822b571b-d07a-445a-980b-235cff7d6d37">
<img width="1005" alt="Screenshot 2024-10-23 at 14 58 17" src="https://github.com/user-attachments/assets/3484d929-1b41-489a-9744-e6db2a42ee09">
<img width="1306" alt="Screenshot 2024-10-23 at 14 58 08" src="https://github.com/user-attachments/assets/0935f171-60ef-4090-bf41-b57a845bf3a4">
