### PR TITLE
UTH-30: add logging to be

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,6 +1,8 @@
+import { logger } from 'onecore-utilities'
+
 import app from './app'
 
 const PORT = process.env.PORT || 7000
 app.listen(PORT, () => {
-  console.log(`listening on http://localhost:${PORT}`)
+  logger.info(`listening on http://localhost:${PORT}`)
 })


### PR DESCRIPTION
https://linear.app/mimer-onecore/issue/UTH-30/anvand-loggningsramverket-i-medportalen-febe

I only added logging to the backend now. I think frontend needs another setup? I might be wrong