### PR TITLE
UTH-35: hide contracts tab from create applicant modal

### DIFF
--- a/packages/frontend/src/pages/ParkingSpaces/components/create-applicant-for-listing/Contracts.tsx
+++ b/packages/frontend/src/pages/ParkingSpaces/components/create-applicant-for-listing/Contracts.tsx
@@ -1,0 +1,82 @@
+import { Typography, Stack } from '@mui/material'
+import { GridColDef } from '@mui/x-data-grid'
+import { Lease } from 'onecore-types'
+import { TabPanel } from '@mui/lab'
+
+import { DataGridTable, Tab } from '../../../../components'
+
+export interface Props {
+  leases: Lease[]
+}
+
+export const Contracts = (props: Props) => {
+  return (
+    <>
+      <Tab
+        label={`Kontrakt (${props.leases.length})`}
+        value="2"
+        disableRipple
+      />
+      <TabPanel value="2" sx={{ padding: 0 }}>
+        <Leases leases={props.leases} />
+      </TabPanel>
+    </>
+  )
+}
+
+const sharedProps = {
+  editable: false,
+  flex: 1,
+}
+
+const columns: GridColDef[] = [
+  {
+    field: 'type',
+    headerName: 'Typ',
+    ...sharedProps,
+  },
+  {
+    field: 'status',
+    headerName: 'Status',
+    ...sharedProps,
+    renderCell: () => 'N/A',
+  },
+  {
+    field: 'address',
+    headerName: 'Adress',
+    ...sharedProps,
+    renderCell: () => 'N/A',
+  },
+  {
+    field: 'monthlyRent',
+    headerName: 'Hyra',
+    ...sharedProps,
+    renderCell: () => 'N/A',
+  },
+]
+
+const Leases = (props: { leases: Lease[] }) => (
+  <DataGridTable
+    sx={{ paddingTop: '1rem' }}
+    initialState={{
+      pagination: { paginationModel: { pageSize: 5 } },
+    }}
+    slots={{
+      noRowsOverlay: () => (
+        <Stack paddingTop="1rem" alignItems="center" justifyContent="center">
+          <Typography fontSize="14px">
+            Det finns inga kontrakt att visa...
+          </Typography>
+        </Stack>
+      ),
+    }}
+    hideFooter
+    columns={columns}
+    rows={props.leases}
+    getRowId={(row) => row.leaseId}
+    loading={false}
+    rowHeight={72}
+    disableRowSelectionOnClick
+    autoHeight
+  />
+)

--- a/packages/frontend/src/pages/ParkingSpaces/components/create-applicant-for-listing/CreateApplicantForListing.tsx
+++ b/packages/frontend/src/pages/ParkingSpaces/components/create-applicant-for-listing/CreateApplicantForListing.tsx
@@ -11,13 +11,11 @@ import {
   Radio,
   FormControlLabel,
   RadioGroup,
-  Stack,
 } from '@mui/material'
 import CloseIcon from '@mui/icons-material/Close'
-import { CreateNoteOfInterestErrorCodes, Lease, Listing } from 'onecore-types'
+import { CreateNoteOfInterestErrorCodes, Listing } from 'onecore-types'
 import { toast } from 'react-toastify'
 import { LoadingButton, TabContext, TabPanel } from '@mui/lab'
-import { GridColDef } from '@mui/x-data-grid'
 
 import {
   CreateNoteOfInterestRequestParams,
@@ -31,7 +29,7 @@ import {
   useTenantWithValidation,
 } from '../../hooks/useTenantWithValidation'
 import { ContactInfo } from './ContactInfo'
-import { DataGridTable, Tab, Tabs } from '../../../../components'
+import { Tab, Tabs } from '../../../../components'
 import { RequestError } from '../../../../types'
 import { ContactInfoLoading } from './ContactInfoLoading'
 
@@ -144,11 +142,11 @@ export const CreateApplicantForListing = (props: Props) => {
                       value="1"
                       sx={{ paddingLeft: 0 }}
                     />
-                    <Tab
-                      label={`Kontrakt (${leases.length})`}
-                      value="2"
-                      disableRipple
-                    />
+                    {/*<Tab*/}
+                    {/*  label={`Kontrakt (${leases.length})`}*/}
+                    {/*  value="2"*/}
+                    {/*  disableRipple*/}
+                    {/*/>*/}
                   </Tabs>
                   <TabPanel value="1" sx={{ padding: 0 }}>
                     <SearchContact
@@ -168,9 +166,7 @@ export const CreateApplicantForListing = (props: Props) => {
                       <Divider />
                     </Box>
                   </TabPanel>
-                  <TabPanel value="2" sx={{ padding: 0 }}>
-                    <Leases leases={leases} />
-                  </TabPanel>
+                  {/*<Contracts leases={leases} />*/}
                 </TabContext>
               </Box>
               {tenantQuery.data &&
@@ -269,63 +265,6 @@ function translateValidationResult(
 
   return translationMap[result]
 }
-
-const sharedProps = {
-  editable: false,
-  flex: 1,
-}
-
-const columns: GridColDef[] = [
-  {
-    field: 'type',
-    headerName: 'Typ',
-    ...sharedProps,
-  },
-  {
-    field: 'status',
-    headerName: 'Status',
-    ...sharedProps,
-    renderCell: () => 'N/A',
-  },
-  {
-    field: 'address',
-    headerName: 'Adress',
-    ...sharedProps,
-    renderCell: () => 'N/A',
-  },
-  {
-    field: 'monthlyRent',
-    headerName: 'Hyra',
-    ...sharedProps,
-    renderCell: () => 'N/A',
-  },
-]
-
-const Leases = (props: { leases: Lease[] }) => (
-  <DataGridTable
-    sx={{ paddingTop: '1rem' }}
-    initialState={{
-      pagination: { paginationModel: { pageSize: 5 } },
-    }}
-    slots={{
-      noRowsOverlay: () => (
-        <Stack paddingTop="1rem" alignItems="center" justifyContent="center">
-          <Typography fontSize="14px">
-            Det finns inga kontrakt att visa...
-          </Typography>
-        </Stack>
-      ),
-    }}
-    hideFooter
-    columns={columns}
-    rows={props.leases}
-    getRowId={(row) => row.leaseId}
-    loading={false}
-    rowHeight={72}
-    disableRowSelectionOnClick
-    autoHeight
-  />
-)
 
 const CreateApplicantError = (props: {
   reset: () => void


### PR DESCRIPTION
I extracted the contracts tab into a separate component. Felt premature to remove it altogether since we might add it again later and that there was some time spent building it in the first place. Let me know if I should just delete it though. 