### PR TITLE
UTH-138: navigate back from parking space detail page

### DIFF
--- a/packages/frontend/src/components/PageGoBack.tsx
+++ b/packages/frontend/src/components/PageGoBack.tsx
@@ -1,0 +1,20 @@
+import { Box, Typography } from '@mui/material'
+import { Link, useNavigate } from 'react-router-dom'
+import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew'
+
+type Props = { text: string }
+
+export const PageGoBack = (props: Props) => {
+  const navigate = useNavigate()
+
+  return (
+    <Link to="#" onClick={() => navigate(-1)}>
+      <Box display="flex" alignItems="center" paddingTop="1rem" gap="0.25rem">
+        <ArrowBackIosNewIcon sx={{ fontSize: 16 }} />
+        <Typography variant="h2" paddingTop="0">
+          {props.text}
+        </Typography>
+      </Box>
+    </Link>
+  )
+}

--- a/packages/frontend/src/pages/ParkingSpace/index.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/index.tsx
@@ -2,7 +2,6 @@ import { Typography } from '@mui/material'
 import { Suspense } from 'react'
 import { useParams } from 'react-router-dom'
 
-import { PageGoBackTo } from '../../components'
 import {
   ApplicantsLoading,
   ParkingSpaceInfo,
@@ -11,6 +10,7 @@ import {
 import { useParkingSpaceListing } from './hooks/useParkingSpaceListing'
 import OffersTabContext from './components/OffersTabContext'
 import AllApplicantsTabContext from './components/AllApplicantsTabContext'
+import { PageGoBack } from '../../components/PageGoBack'
 
 const ParkingSpace = () => {
   const routeParams = useParams<'id'>()
@@ -19,7 +19,7 @@ const ParkingSpace = () => {
 
   return (
     <>
-      <PageGoBackTo to="/parkingspaces" text="Översikt lediga bilplatser" />
+      <PageGoBack text="Översikt lediga bilplatser" />
       <Suspense fallback={<ApplicantsLoading />}>
         <ParkingSpaceTabs listingId={listingId} />
       </Suspense>

--- a/packages/frontend/src/pages/ParkingSpaces/components/create-applicant-for-listing/CreateApplicantForListing.tsx
+++ b/packages/frontend/src/pages/ParkingSpaces/components/create-applicant-for-listing/CreateApplicantForListing.tsx
@@ -75,11 +75,6 @@ export const CreateApplicantForListing = (props: Props) => {
   const handleChange = (_e: React.SyntheticEvent, tab: string) =>
     setSelectedTab(tab)
 
-  const leases =
-    tenantQuery.data?.tenant.housingContracts.concat(
-      tenantQuery.data.tenant.parkingSpaceContracts ?? []
-    ) ?? []
-
   return (
     <>
       <Button


### PR DESCRIPTION
Before: 
Going back from detail page doesnt respect filters and just takes you to /

After:
Explicitly go back when pressing the "översikt lediga bilplatser" button.

It's not a bullet proof solution but I think it's good enough for now..

Fixes https://linear.app/mimer-onecore/issue/UTH-138/kunna-navigera-bakat-och-vara-kvar-i-samma-state