### PR TITLE
UTH-139: fix queryKey to refetch listing after new note of interest

### DIFF
--- a/packages/frontend/src/pages/ParkingSpaces/hooks/useCreateNoteOfInterest.ts
+++ b/packages/frontend/src/pages/ParkingSpaces/hooks/useCreateNoteOfInterest.ts
@@ -34,7 +34,7 @@ export const useCreateNoteOfInterest = (listingId: number) => {
     onSuccess: () =>
       Promise.all([
         queryClient.refetchQueries({
-          queryKey: ['parkingSpaceListing', String(listingId)],
+          queryKey: ['parkingSpaceListing', listingId],
         }),
         queryClient.invalidateQueries({
           queryKey: ['parkingSpaceListings'],


### PR DESCRIPTION
¯\_(ツ)_/¯

(Query key to refetch listing was casted to string in this case. The initial and all the other usages of this query has a number based query key. Meaning that in this instance the query to refetch was never matched when creating a new note of interest)