### PR TITLE
Hide Change/Additional option for contacts without current or upcoming parking space contracts

### DIFF
--- a/packages/backend/src/services/leasing-service/index.ts
+++ b/packages/backend/src/services/leasing-service/index.ts
@@ -2,6 +2,7 @@ import KoaRouter from '@koa/router'
 import { generateRouteMetadata } from 'onecore-utilities'
 
 import * as coreAdapter from './adapters/core-adapter'
+import { LeaseStatus } from 'onecore-types'
 
 export const routes = (router: KoaRouter) => {
   router.get('(.*)/leases/listings-with-applicants', async (ctx) => {
@@ -136,7 +137,11 @@ export const routes = (router: KoaRouter) => {
 
         if (
           getTenant.data.parkingSpaceContracts &&
-          getTenant.data.parkingSpaceContracts.length > 0
+          getTenant.data.parkingSpaceContracts.filter(
+            (l) =>
+              l.status == LeaseStatus.Current ||
+              l.status == LeaseStatus.Upcoming
+          ).length > 0
         )
           return {
             ok: true,

--- a/packages/frontend/src/pages/ParkingSpace/components/Applicants.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/components/Applicants.tsx
@@ -71,7 +71,7 @@ const getColumns = (listingId: number, address: string): Array<GridColDef> => {
       field: 'contactCode',
       headerName: 'Kundnummer',
       ...sharedProps,
-      flex: 1.25,
+      flex: 1,
     },
     {
       field: 'queuePoints',
@@ -109,10 +109,16 @@ const getColumns = (listingId: number, address: string): Array<GridColDef> => {
     },
     {
       field: 'parkingSpaceContracts',
-      headerName: 'Har bilplats',
-      valueFormatter: (v) => (v.value.length ? 'Ja' : 'Nej'),
+      headerName: 'Har bilplats (G/K)',
+      valueFormatter: (v) =>
+        v.value.filter(
+          (l: any) =>
+            l.status == LeaseStatus.Current || l.status == LeaseStatus.Upcoming
+        ).length
+          ? 'Ja'
+          : 'Nej',
       ...sharedProps,
-      flex: 0.75,
+      flex: 1,
     },
     {
       field: 'status',

--- a/packages/frontend/src/pages/ParkingSpace/components/OfferRound.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/components/OfferRound.tsx
@@ -68,7 +68,7 @@ const getColumns = (expiresAt: Date): Array<GridColDef> => {
       field: 'contactCode',
       headerName: 'Kundnummer',
       ...sharedProps,
-      flex: 1.25,
+      flex: 1,
     },
     {
       field: 'queuePoints',
@@ -99,10 +99,16 @@ const getColumns = (expiresAt: Date): Array<GridColDef> => {
     },
     {
       field: 'hasParkingSpace',
-      headerName: 'Har bilplats',
-      valueFormatter: (v) => (v.value ? 'Ja' : 'Nej'),
+      headerName: 'Har bilplats (G/K)',
+      valueFormatter: (v) =>
+        v.value.filter(
+          (l: any) =>
+            l.status == LeaseStatus.Current || l.status == LeaseStatus.Upcoming
+        ).length
+          ? 'Ja'
+          : 'Nej',
       ...sharedProps,
-      flex: 0.75,
+      flex: 1,
     },
     {
       field: 'status',

--- a/packages/frontend/src/pages/ParkingSpaces/components/create-applicant-for-listing/ListingInfo.tsx
+++ b/packages/frontend/src/pages/ParkingSpaces/components/create-applicant-for-listing/ListingInfo.tsx
@@ -1,5 +1,6 @@
 import { Box, Typography } from '@mui/material'
 import { Listing } from 'onecore-types'
+
 import { printVacantFrom } from '../../../../common/formattingUtils'
 
 export const ListingInfo = (props: { listing: Listing }) => {


### PR DESCRIPTION
* Har bilplats-column now only applies to current and upcoming contacts
* Option to Byta or Hyra en till now only shows up for customers with current ang upcoming contracts