### PR TITLE
Feat: UTH-216 Show Error Message When No Valid Housing Contract is Found

### DIFF
--- a/packages/backend/package-lock.json
+++ b/packages/backend/package-lock.json
@@ -20,7 +20,7 @@
         "koa-jwt": "^4.0.4",
         "koa-pino-logger": "^4.0.0",
         "koa-session": "^6.4.0",
-        "onecore-types": "^2.1.0",
+        "onecore-types": "^3.5.1",
         "onecore-utilities": "^1.1.0"
       },
       "devDependencies": {
@@ -7309,9 +7309,10 @@
       }
     },
     "node_modules/onecore-types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/onecore-types/-/onecore-types-2.1.0.tgz",
-      "integrity": "sha512-3p5yuvm9kd7jwqK1G207U3iL3Ndj3RuPdYE3sK/Yf3bH7ndGfg9dJ3nbUofpbVZh3cIsDcNy9SDdFQjNVWevFQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/onecore-types/-/onecore-types-3.5.1.tgz",
+      "integrity": "sha512-XLmtOf3LqWiprX5dVnu2CWf9DcucfirUDSu6X6TEFNYHS1kxpGZEag6/pdICFoFJihg1FYqOSmmkN5ehKwAsfQ==",
+      "license": "ISC",
       "dependencies": {
         "release-please": "^16.8.0"
       },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -51,7 +51,7 @@
     "koa-jwt": "^4.0.4",
     "koa-pino-logger": "^4.0.0",
     "koa-session": "^6.4.0",
-    "onecore-types": "^2.1.0",
+    "onecore-types": "^3.5.1",
     "onecore-utilities": "^1.1.0"
   }
 }

--- a/packages/backend/src/services/leasing-service/adapters/core-adapter.ts
+++ b/packages/backend/src/services/leasing-service/adapters/core-adapter.ts
@@ -134,9 +134,7 @@ const getTenantByContactCode = async (
     return { ok: true, data: result.content }
   } catch (err) {
     if (err instanceof AxiosError && err.response?.status === 500) {
-      if (err.response.data.type) {
-        return { ok: false, err: err.response.data.type, statusCode: 500 }
-      }
+      return { ok: false, err: err.response?.data?.type, statusCode: 500 }
     }
 
     return { ok: false, err, statusCode: 500 }

--- a/packages/backend/src/services/leasing-service/adapters/core-adapter.ts
+++ b/packages/backend/src/services/leasing-service/adapters/core-adapter.ts
@@ -119,7 +119,12 @@ const getContactsDataBySearchQuery = async (
 
 const getTenantByContactCode = async (
   contactCode: string
-): Promise<AdapterResult<Tenant, unknown>> => {
+): Promise<
+  AdapterResult<
+    Tenant,
+    unknown | 'no-valid-housing-contract' | 'contact-not-found'
+  >
+> => {
   try {
     const result = await getFromCore<{ content: Tenant }>({
       method: 'get',
@@ -128,6 +133,12 @@ const getTenantByContactCode = async (
 
     return { ok: true, data: result.content }
   } catch (err) {
+    if (err instanceof AxiosError && err.response?.status === 500) {
+      if (err.response.data.type) {
+        return { ok: false, err: err.response.data.type, statusCode: 500 }
+      }
+    }
+
     return { ok: false, err, statusCode: 500 }
   }
 }

--- a/packages/backend/src/services/leasing-service/index.ts
+++ b/packages/backend/src/services/leasing-service/index.ts
@@ -84,6 +84,19 @@ export const routes = (router: KoaRouter) => {
       const getTenant = await coreAdapter.getTenantByContactCode(
         ctx.params.contactCode
       )
+      if (!getTenant.ok && getTenant.err === 'no-valid-housing-contract') {
+        ctx.status = 403
+        ctx.body = {
+          // reason: 'no-valid-housing-contract',
+          // error: 'Valid housing contaract not found',
+          type: 'no-valid-housing-contract',
+          title: 'No valid housing contract found',
+          status: 403,
+          detail:
+            'A housing contract needs to be current or upcoming to be a valid contract when applying for a parking space.',
+        }
+        return
+      }
 
       if (!getTenant.ok) {
         ctx.status = 500
@@ -157,7 +170,7 @@ export const routes = (router: KoaRouter) => {
       })
 
       if (!validate.ok) {
-        ctx.status = 500
+        ctx.status = 403
         return
       }
 

--- a/packages/backend/src/services/leasing-service/index.ts
+++ b/packages/backend/src/services/leasing-service/index.ts
@@ -2,7 +2,7 @@ import KoaRouter from '@koa/router'
 import { generateRouteMetadata } from 'onecore-utilities'
 
 import * as coreAdapter from './adapters/core-adapter'
-import { LeaseStatus } from 'onecore-types'
+import { LeaseStatus, RouteErrorResponse } from 'onecore-types'
 
 export const routes = (router: KoaRouter) => {
   router.get('(.*)/leases/listings-with-applicants', async (ctx) => {
@@ -81,20 +81,21 @@ export const routes = (router: KoaRouter) => {
   router.get(
     '(.*)/get-and-validate-tenant/:contactCode/:districtCode/:rentalObjectCode',
     async (ctx) => {
+      const metadata = generateRouteMetadata(ctx)
+
       const getTenant = await coreAdapter.getTenantByContactCode(
         ctx.params.contactCode
       )
       if (!getTenant.ok && getTenant.err === 'no-valid-housing-contract') {
         ctx.status = 403
         ctx.body = {
-          // reason: 'no-valid-housing-contract',
-          // error: 'Valid housing contaract not found',
           type: 'no-valid-housing-contract',
           title: 'No valid housing contract found',
           status: 403,
           detail:
             'A housing contract needs to be current or upcoming to be a valid contract when applying for a parking space.',
-        }
+          ...metadata,
+        } satisfies RouteErrorResponse
         return
       }
 

--- a/packages/frontend/src/pages/ParkingSpaces/components/create-applicant-for-listing/CreateApplicantForListing.tsx
+++ b/packages/frontend/src/pages/ParkingSpaces/components/create-applicant-for-listing/CreateApplicantForListing.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   Button,
   Dialog,
@@ -152,11 +152,22 @@ export const CreateApplicantForListing = (props: Props) => {
                       <ContactInfo tenant={tenantQuery.data?.tenant ?? null} />
                     )}
                     {tenantQuery.isLoading && <ContactInfoLoading />}
-                    {tenantQuery.error && (
-                      <Typography color="error">
-                        Något gick fel. Kontakta support.
-                      </Typography>
-                    )}
+                    {tenantQuery.error &&
+                      tenantQuery.error?.response?.data?.type ===
+                        'no-valid-housing-contract' && (
+                        <Typography color="error">
+                          Kunden saknar giltigt bostadskontrakt. Det går endast
+                          att söka bilplats med gällande och kommande
+                          bostadskontrakt
+                        </Typography>
+                      )}
+                    {tenantQuery.error &&
+                      tenantQuery.error?.response?.data?.type !=
+                        'no-valid-housing-contract' && (
+                        <Typography color="error">
+                          Något gick fel. Kontakta support.
+                        </Typography>
+                      )}
                     <Box>
                       <Divider />
                     </Box>

--- a/packages/frontend/src/pages/ParkingSpaces/components/create-applicant-for-listing/CreateApplicantForListing.tsx
+++ b/packages/frontend/src/pages/ParkingSpaces/components/create-applicant-for-listing/CreateApplicantForListing.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import {
   Button,
   Dialog,
@@ -75,6 +75,22 @@ export const CreateApplicantForListing = (props: Props) => {
   const handleChange = (_e: React.SyntheticEvent, tab: string) =>
     setSelectedTab(tab)
 
+  const renderTenantQueryError = (error: any) => {
+    if (!error) return null
+
+    if (error?.response?.data?.type === 'no-valid-housing-contract') {
+      return (
+        <Typography color="error">
+          Kunden saknar giltigt bostadskontrakt. Det går endast att söka
+          bilplats med gällande och kommande bostadskontrakt
+        </Typography>
+      )
+    }
+
+    return (
+      <Typography color="error">Något gick fel. Kontakta support.</Typography>
+    )
+  }
   return (
     <>
       <Button
@@ -152,22 +168,7 @@ export const CreateApplicantForListing = (props: Props) => {
                       <ContactInfo tenant={tenantQuery.data?.tenant ?? null} />
                     )}
                     {tenantQuery.isLoading && <ContactInfoLoading />}
-                    {tenantQuery.error &&
-                      tenantQuery.error?.response?.data?.type ===
-                        'no-valid-housing-contract' && (
-                        <Typography color="error">
-                          Kunden saknar giltigt bostadskontrakt. Det går endast
-                          att söka bilplats med gällande och kommande
-                          bostadskontrakt
-                        </Typography>
-                      )}
-                    {tenantQuery.error &&
-                      tenantQuery.error?.response?.data?.type !=
-                        'no-valid-housing-contract' && (
-                        <Typography color="error">
-                          Något gick fel. Kontakta support.
-                        </Typography>
-                      )}
+                    {renderTenantQueryError(tenantQuery.error)}
                     <Box>
                       <Divider />
                     </Box>

--- a/packages/frontend/src/pages/ParkingSpaces/hooks/useTenantWithValidation.ts
+++ b/packages/frontend/src/pages/ParkingSpaces/hooks/useTenantWithValidation.ts
@@ -41,7 +41,7 @@ export const useTenantWithValidation = (
         )
         .then((res) => res.data),
     retry: (failureCount: number, error: AxiosError) => {
-      if (error.response?.status === 401) {
+      if (error.response?.status === 401 || error.response?.status === 403) {
         return false
       } else {
         return failureCount < 3


### PR DESCRIPTION
* Adapter can now return no-valid-housing-contract
* Route now returns errors according to RFC 7807 standard
* Error message is shown in the view
* Query won't retry for 403-messages