### PR TITLE
Fix: UTH-206 District Mismatch Error Adjustment

### DIFF
--- a/packages/frontend/src/pages/ParkingSpaces/components/create-applicant-for-listing/CreateApplicantForListing.tsx
+++ b/packages/frontend/src/pages/ParkingSpaces/components/create-applicant-for-listing/CreateApplicantForListing.tsx
@@ -281,7 +281,10 @@ function translateValidationResult(
 
 function renderWarningIfDistrictsMismatch(listing: Listing, tenant: Tenant) {
   if (
-    listing.districtCode != tenant.currentHousingContract?.residentialArea?.code
+    tenant.upcomingHousingContract?.residentialArea?.code !==
+      listing.districtCode &&
+    tenant.currentHousingContract?.residentialArea?.code !==
+      listing.districtCode
   ) {
     return (
       <Box paddingBottom={'1rem'}>


### PR DESCRIPTION
* District error won't show if contact has either an upcoming or an active housning contract