### PR TITLE
Feat: UTH-212 Parking Spaces for Secret Identities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onecore-internal-portal",
-  "version": "1.0.106",
+  "version": "1.0.107",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "onecore-internal-portal",
-      "version": "1.0.106",
+      "version": "1.0.107",
       "license": "ISC"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onecore-internal-portal",
-  "version": "1.0.106",
+  "version": "1.0.107",
   "description": "Coworker web portal",
   "main": "index.js",
   "scripts": {

--- a/packages/frontend/src/pages/ParkingSpace/components/Applicants.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/components/Applicants.tsx
@@ -175,7 +175,7 @@ const getColumns = (listingId: number, address: string): Array<GridColDef> => {
             disabled={v.row.status !== ApplicantStatus.Active}
             listingId={listingId}
             applicantId={v.row.id}
-            applicantName={v.row.name}
+            applicantName={v.row.name ?? v.row.contactCode}
             listingAddress={address}
           />
         )

--- a/packages/frontend/src/pages/ParkingSpace/components/OfferRound.tsx
+++ b/packages/frontend/src/pages/ParkingSpace/components/OfferRound.tsx
@@ -156,7 +156,11 @@ const getColumns = (expiresAt: Date): Array<GridColDef> => {
           <OfferRoundActions
             disabled={v.row.status !== ApplicantStatus.Offered}
             listingId={v.row.listingId}
-            applicantName={v.row.name}
+            applicantName={
+              v.row.name && v.row.name.length > -1
+                ? v.row.name
+                : v.row.contactCode
+            }
             offerId={v.row.offerId}
           />
         )


### PR DESCRIPTION
A contact with secret identity should be able to rent an internal parking space. A contact with a secret identity doesn't have name or national security number set

* Handle contacts without name