### PR TITLE
Changed housing type form settings and fixed spelling

### DIFF
--- a/packages/frontend/src/components/SiteMenu.tsx
+++ b/packages/frontend/src/components/SiteMenu.tsx
@@ -46,12 +46,12 @@ const SiteMenu = () => (
                 <Typography>Bilplatser</Typography>
               </MenuItem>
             </Link>
-
+            {/* 
             <Link to="/materialval">
               <MenuItem onClick={popupState.close}>
                 <Typography>Materialval</Typography>
               </MenuItem>
-            </Link>
+            </Link> */}
 
             <Link to="/sokandeprofil">
               <MenuItem onClick={popupState.close}>

--- a/packages/frontend/src/pages/Residences/components/Form/HousingType.tsx
+++ b/packages/frontend/src/pages/Residences/components/Form/HousingType.tsx
@@ -45,7 +45,7 @@ const HousingType = () => {
                 </MenuItem>
 
                 <MenuItem value="RENTAL">Hyresrätt</MenuItem>
-                <MenuItem value="SUB_RENTAL">Andrahand</MenuItem>
+                <MenuItem value="SUB_RENTAL">Andra hand</MenuItem>
                 <MenuItem value="LIVES_WITH_FAMILY">Bor hos förälder</MenuItem>
                 <MenuItem value="LODGER">Inneboende</MenuItem>
                 <MenuItem value="OWNS_HOUSE">Äger villa</MenuItem>

--- a/packages/frontend/src/pages/Residences/model/conditional.ts
+++ b/packages/frontend/src/pages/Residences/model/conditional.ts
@@ -6,14 +6,14 @@ export const housingFieldMatrix: Record<string, readonly string[]> = {
     'housingReference.phone',
     'housingReference.email',
   ],
-  ['LIVES_WITH_FAMILY']: [
+  ['LODGER']: [
     'landlord',
     'numAdults',
     'numChildren',
     'housingReference.phone',
     'housingReference.email',
   ],
-  ['LODGER']: ['numAdults', 'numChildren'],
+  ['LIVES_WITH_FAMILY']: ['numAdults', 'numChildren'],
   ['OWNS_HOUSE']: ['numAdults', 'numChildren'],
   ['OWNS_FLAT']: ['numAdults', 'numChildren'],
   ['OWNS_ROW_HOUSE']: ['numAdults', 'numChildren'],

--- a/packages/frontend/src/pages/Residences/model/conditional.ts
+++ b/packages/frontend/src/pages/Residences/model/conditional.ts
@@ -6,13 +6,14 @@ export const housingFieldMatrix: Record<string, readonly string[]> = {
     'housingReference.phone',
     'housingReference.email',
   ],
-  ['LODGER']: [
+  ['SUB_RENTAL']: [
     'landlord',
     'numAdults',
     'numChildren',
     'housingReference.phone',
     'housingReference.email',
   ],
+  ['LODGER']: ['numAdults', 'numChildren'],
   ['LIVES_WITH_FAMILY']: ['numAdults', 'numChildren'],
   ['OWNS_HOUSE']: ['numAdults', 'numChildren'],
   ['OWNS_FLAT']: ['numAdults', 'numChildren'],


### PR DESCRIPTION
The housing type SUB_RENTAL should provide details for housing reference
The housing type LIVES_WITH_FAMILY should not

Andrahand is spelled out as Andra hand on Mimer.nu